### PR TITLE
Handle syntax errors appearing during a commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Refer to [EXAMPLES.md](EXAMPLES.md) for screenshots of each step.
 
 | Plugin Versions | NetBox Versions | Panorama versions |
 |:---------------:|:---------------:|:-----------------:|
+|  1.1.1          | 4.5.x           |  10.2.10, 11.1.6  |
 |  1.1.0          | 4.5.x           |  10.2.10, 11.1.6  |
 |  1.0.7 - 1.0.8  | 4.2.5 - 4.4.10  |  10.2.10, 11.1.6  |
 |  1.0.0 - 1.0.6  | 4.2.5 - 4.3.7   |  10.2.10, 11.1.6  |

--- a/netbox_panorama_configpump_plugin/device_config_sync_status/panorama.py
+++ b/netbox_panorama_configpump_plugin/device_config_sync_status/panorama.py
@@ -94,6 +94,14 @@ class PanoramaLogger:
         return sanitize_nested_values(log_entries)
 
 
+def _append_job_progress_detail(message: str, progress_detail: Any) -> str:
+    """Append Panorama job details to a log message as a single line."""
+    detail = extract_strings_from_nested(progress_detail).strip()
+    if detail:
+        return f"{message} — {detail}"
+    return message
+
+
 class PanoramaMixin:
     """Mixin class providing common Panorama-related functionality."""
 
@@ -564,6 +572,8 @@ class PanoramaMixin:
                 if not isinstance(job, dict):
                     continue
 
+                progress_detail = job.get("details")
+
                 job_result = job.get("result")
                 if not isinstance(job_result, str):
                     continue
@@ -572,22 +582,49 @@ class PanoramaMixin:
                 if not isinstance(progress, str):
                     continue
 
-                if job_result.strip().lower() != "ok":
+                normalized_result = job_result.strip().lower()
+                job_status = job.get("status")
+                normalized_status = (
+                    job_status.strip().lower() if isinstance(job_status, str) else ""
+                )
+
+                if normalized_result == "ok":
                     panorama_logger.log(
-                        Status.PENDING,
+                        Status.SUCCESS,
                         http_status_code,
                         call_type,
-                        f"Commit job progress: {progress}%",
+                        _append_job_progress_detail(
+                            f"Commit job '{commit_job_id}' completed successfully",
+                            progress_detail,
+                        ),
                     )
-                    continue
+                    return True
+
+                if (
+                    normalized_result in ("fail", "failed")
+                    or normalized_status == "fin"
+                ):
+                    panorama_logger.log(
+                        Status.FAILURE,
+                        http_status_code,
+                        call_type,
+                        _append_job_progress_detail(
+                            f"Commit job '{commit_job_id}' failed (result: {job_result.strip()})",
+                            progress_detail,
+                        ),
+                    )
+                    return False
 
                 panorama_logger.log(
-                    Status.SUCCESS,
+                    Status.PENDING,
                     http_status_code,
                     call_type,
-                    f"Commit job '{commit_job_id}' completed successfully",
+                    _append_job_progress_detail(
+                        f"Commit job progress: {progress}%",
+                        progress_detail,
+                    ),
                 )
-                return True
+                continue
 
             panorama_logger.log(
                 Status.FAILURE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name =  "netbox-panorama-configpump-plugin"
-version = "1.1.0"
+version = "1.1.1"
 description = "A NetBox plugin that synchronizes Palo Alto Networks Panorama configuration from NetBox data using a pull, diff and push workflow."
 authors = ["Veikko Pankakoski <veikko@rautanen.io>", "Jaakko Rautanen <jaakko@rautanen.io>"]
 license = "Apache-2.0"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -975,7 +975,14 @@ class PanoramaPushTests(TestCase):
         )
         self.assertEqual(
             panorama_logger.entries[9].response,
-            "Commit job '70' completed successfully",
+            (
+                "Commit job '70' completed successfully — "
+                "Configuration committed successfully "
+                "Local configuration size: 9 KB "
+                "Predefined configuration size: 14 MB "
+                "Total configuration size(local, predefined): 14 MB "
+                "Maximum recommended configuration size: 120 MB (11% configured)"
+            ),
         )
         self.assertEqual(
             panorama_logger.entries[10].response,


### PR DESCRIPTION
Fixes how the plugin handles Panorama commit jobs that fail with configuration syntax errors.

Commit job polling now treats fail/failed results and finished jobs (status: FIN) as failures instead of ongoing progress, so a failed commit stops the push workflow and surfaces the error correctly.

Job detail text from Panorama (including syntax error messages) is appended to success, failure, and progress log entries via a new helper.