### PR TITLE
Refresh Panorama configuration in the background when triggered by a signal

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/enforce_version_bump.yml
+++ b/.github/workflows/enforce_version_bump.yml
@@ -9,13 +9,13 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python and Poetry
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/tag-new-release.yml
+++ b/.github/workflows/tag-new-release.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python & Poetry
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.13
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Refer to [EXAMPLES.md](EXAMPLES.md) for screenshots of each step.
 
 | Plugin Versions | NetBox Versions | Panorama versions |
 |:---------------:|:---------------:|:-----------------:|
+|  1.1.3          | 4.5.x           |  10.2.10, 11.1.6  |
 |  1.1.2          | 4.5.x           |  10.2.10, 11.1.6  |
 |  1.1.1          | 4.5.x           |  10.2.10, 11.1.6  |
 |  1.1.0          | 4.5.x           |  10.2.10, 11.1.6  |

--- a/netbox_panorama_configpump_plugin/device_config_sync_status/jobs.py
+++ b/netbox_panorama_configpump_plugin/device_config_sync_status/jobs.py
@@ -135,3 +135,34 @@ class PullDeviceConfigJobRunner(JobRunner):
         _update_device_config_sync_status(
             device_config_sync_status, pull_time=timezone.now()
         )
+
+
+class RecomputeDeviceConfigSyncStatusJobRunner(JobRunner):
+    """Job runner for recomputing rendered config status and diffs."""
+
+    # pylint: disable=too-few-public-methods
+    class Meta:
+        """Meta options for RecomputeDeviceConfigSyncStatusJobRunner."""
+
+        name = "Recompute Device Config Sync Status"
+
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        device_config_sync_status_id = kwargs.get("device_config_sync_status_id")
+        if not device_config_sync_status_id:
+            raise ValueError("device_config_sync_status_id is required")
+
+        device_config_sync_status = DeviceConfigSyncStatus.objects.filter(
+            id=device_config_sync_status_id
+        ).first()
+        if not device_config_sync_status:
+            raise ValueError("Device config sync status not found")
+
+        # config_render_ok and diffs are updated by save
+        device_config_sync_status.save(
+            update_fields=[
+                "config_render_ok",
+                "lines_added",
+                "lines_removed",
+                "lines_changed",
+            ]
+        )

--- a/netbox_panorama_configpump_plugin/signals.py
+++ b/netbox_panorama_configpump_plugin/signals.py
@@ -13,28 +13,27 @@ from typing import Any
 
 from dcim.models import Device, DeviceRole, Interface, Platform
 from dcim.models.devices import post_save
-from django.db.models import QuerySet
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from extras.models import ConfigTemplate
 
+from netbox_panorama_configpump_plugin.device_config_sync_status.jobs import (
+    RecomputeDeviceConfigSyncStatusJobRunner,
+)
 from netbox_panorama_configpump_plugin.device_config_sync_status.models import (
     DeviceConfigSyncStatus,
 )
 
 
-def _update_device_config_sync_statuses(
-    device_config_sync_statuses: QuerySet[DeviceConfigSyncStatus],
+def _enqueue_device_config_sync_status_recompute_jobs(
+    device_config_sync_statuses: list[DeviceConfigSyncStatus],
 ) -> None:
     for device_config_sync_status in device_config_sync_statuses:
-        # config_render_ok and diffs are updated by save
-        device_config_sync_status.save(
-            update_fields=[
-                "config_render_ok",
-                "lines_added",
-                "lines_removed",
-                "lines_changed",
-            ]
+        # pylint: disable=line-too-long
+        RecomputeDeviceConfigSyncStatusJobRunner.enqueue(
+            instance=device_config_sync_status,
+            name=f"Recompute config sync status for {device_config_sync_status.device.name}",
+            device_config_sync_status_id=device_config_sync_status.id,
         )
 
 
@@ -47,12 +46,14 @@ def update_device_config_sync_status_on_config_template_change(
     Update the device config sync statuses for a config template.
     """
 
-    device_config_sync_statuses = DeviceConfigSyncStatus.objects.filter(
-        device__in=Device.objects.filter(platform__in=instance.platforms.all())
+    device_config_sync_statuses = list(
+        DeviceConfigSyncStatus.objects.filter(
+            device__in=Device.objects.filter(platform__in=instance.platforms.all())
+        )
     )
     if not device_config_sync_statuses:
         return
-    _update_device_config_sync_statuses(device_config_sync_statuses)
+    _enqueue_device_config_sync_status_recompute_jobs(device_config_sync_statuses)
 
 
 # pylint: disable=unused-argument
@@ -64,11 +65,13 @@ def update_device_config_sync_status_on_device_change(
     Update the device config sync statuses for a device.
     """
 
-    device_config_sync_statuses = DeviceConfigSyncStatus.objects.filter(device=instance)
+    device_config_sync_statuses = list(
+        DeviceConfigSyncStatus.objects.filter(device=instance)
+    )
     if not device_config_sync_statuses:
         return
 
-    _update_device_config_sync_statuses(device_config_sync_statuses)
+    _enqueue_device_config_sync_status_recompute_jobs(device_config_sync_statuses)
 
 
 # pylint: disable=unused-argument
@@ -82,14 +85,14 @@ def update_device_config_sync_status_on_interface_change(
     updated, or deleted.
     """
 
-    device_config_sync_statuses = DeviceConfigSyncStatus.objects.filter(
-        device=instance.device
+    device_config_sync_statuses = list(
+        DeviceConfigSyncStatus.objects.filter(device=instance.device)
     )
 
     if not device_config_sync_statuses:
         return
 
-    _update_device_config_sync_statuses(device_config_sync_statuses)
+    _enqueue_device_config_sync_status_recompute_jobs(device_config_sync_statuses)
 
 
 # pylint: disable=unused-argument
@@ -101,13 +104,13 @@ def update_device_config_sync_status_on_platform_change(
     Update the device config sync statuses for a platform.
     """
 
-    device_config_sync_statuses = DeviceConfigSyncStatus.objects.filter(
-        device__platform=instance
+    device_config_sync_statuses = list(
+        DeviceConfigSyncStatus.objects.filter(device__platform=instance)
     )
     if not device_config_sync_statuses:
         return
 
-    _update_device_config_sync_statuses(device_config_sync_statuses)
+    _enqueue_device_config_sync_status_recompute_jobs(device_config_sync_statuses)
 
 
 # pylint: disable=unused-argument
@@ -119,10 +122,12 @@ def update_device_config_sync_status_on_device_role_change(
     Update the device config sync statuses for a device role.
     """
 
-    device_config_sync_statuses = DeviceConfigSyncStatus.objects.filter(
-        device__in=Device.objects.filter(role=instance)
+    device_config_sync_statuses = list(
+        DeviceConfigSyncStatus.objects.filter(
+            device__in=Device.objects.filter(role=instance)
+        )
     )
     if not device_config_sync_statuses:
         return
 
-    _update_device_config_sync_statuses(device_config_sync_statuses)
+    _enqueue_device_config_sync_status_recompute_jobs(device_config_sync_statuses)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name =  "netbox-panorama-configpump-plugin"
-version = "1.1.2"
+version = "1.1.3"
 description = "A NetBox plugin that synchronizes Palo Alto Networks Panorama configuration from NetBox data using a pull, diff and push workflow."
 authors = ["Veikko Pankakoski <veikko@rautanen.io>", "Jaakko Rautanen <jaakko@rautanen.io>"]
 license = "Apache-2.0"

--- a/tests/test_device_config_sync_status.py
+++ b/tests/test_device_config_sync_status.py
@@ -5,6 +5,7 @@
 
 import datetime
 import uuid
+from unittest.mock import patch
 
 from core.choices import JobStatusChoices
 from core.models import Job
@@ -164,22 +165,29 @@ class DeviceConfigSyncStatusModelTests(TestDeviceConfigSyncStatusMixing):
         obj.save()
         self.assertFalse(obj.config_render_ok)
 
-    def test_signals_trigger_diffs_and_config_render_ok(self):
+    @patch(
+        "netbox_panorama_configpump_plugin.signals.RecomputeDeviceConfigSyncStatusJobRunner.enqueue"
+    )
+    def test_signals_enqueue_recompute_jobs(self, enqueue_mock):
         obj = DeviceConfigSyncStatus.objects.create(
             device=self.device1,
             connection=self.connection1,
         )
 
-        # Device change:
+        # Manual status save (not one of the monitored signal senders):
         self.config_template.template_code = "<root></root>"
         obj.save()
-        self.assertTrue(obj.config_render_ok)
 
         # ConfigTemplate change:
         self.config_template.template_code = "<root></rot>"
         self.config_template.save()
-        obj.refresh_from_db()
-        self.assertFalse(obj.config_render_ok)
+
+        self.assertEqual(enqueue_mock.call_count, 1)
+        enqueue_mock.assert_any_call(
+            instance=obj,
+            name=f"Recompute config sync status for {obj.device.name}",
+            device_config_sync_status_id=obj.id,
+        )
 
 
 class ConnectionViewTests(TestDeviceConfigSyncStatusMixing):


### PR DESCRIPTION
Currently, if a firewall configuration contains complex Jinja processing, saving related ConfigTemplate, Device, Interface, Platform or DeviceRole objects can take a long time. User's NetBox session is frozen until the configuration processing is complated. After this change, configurations are updated by a NetBox worker in the background, therefore improving the user experience.

Also, updates Github actions to the latest versions.
